### PR TITLE
fix: prevent IPv6 upstream resolution in nginx proxy

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -2,11 +2,14 @@ worker_processes auto;
 events { worker_connections 1024; }
 http {
     sendfile on;
+    client_max_body_size 64M; # Support large session recording uploads
+
+    # This resolver is IGNORED by hardcoded proxy_pass, but USED by variables
+    resolver 8.8.8.8 8.8.4.4 valid=30s ipv6=off;
+
     server {
         listen ${PORT};
         server_name ${SERVER_NAME};
-        # DNS resolver
-        resolver 8.8.8.8 8.8.4.4 valid=1s ipv6=off;
         
         # Health check endpoint
         location = /health {
@@ -17,8 +20,9 @@ http {
         
         # Static assets - from us-assets.i.posthog.com
         location /static {
-            proxy_pass https://${POSTHOG_CLOUD_REGION}-assets.i.posthog.com;
-            proxy_set_header Host "${POSTHOG_CLOUD_REGION}-assets.i.posthog.com";
+            set $ph_assets ${POSTHOG_CLOUD_REGION}-assets.i.posthog.com;
+            proxy_pass https://$ph_assets;
+            proxy_set_header Host $ph_assets;
             proxy_ssl_server_name on;
             
             # Remove upstream CORS headers to prevent duplicates
@@ -36,8 +40,9 @@ http {
         
         # Main API endpoints
         location / {
-            proxy_pass https://${POSTHOG_CLOUD_REGION}.i.posthog.com;
-            proxy_set_header Host "${POSTHOG_CLOUD_REGION}.i.posthog.com";
+            set $ph_ingest ${POSTHOG_CLOUD_REGION}.i.posthog.com;
+            proxy_pass https://$ph_ingest;
+            proxy_set_header Host $ph_ingest;
             proxy_ssl_server_name on;
             
             # Remove upstream CORS headers to prevent duplicates


### PR DESCRIPTION
nginx resolves literal proxy_pass hostnames at startup and may select IPv6 (AAAA) records. In environments like Railway, IPv6 egress is unavailable, causing intermittent upstream connection failures.

This change forces runtime DNS resolution by using variable-based proxy_pass and disables IPv6 via the resolver, ensuring only IPv4 addresses are used when proxying requests to PostHog.

Example 

```
2026/01/22 00:43:07 [error] 24#24: *385 connect() to [2600:1f18:4c12:9a00:3334:bdf9:b46b:5b11]:443 failed (101: Network is unreachable) while connecting to upstream, client: 100.64.0.3, server:<redacted>, request: "POST /i/v0/e/?ip=0&_=1769042587131&ver=1.333.0&compression=gzip-js HTTP/1.1", upstream: "https://[2600:1f18:4c12:9a00:3334:bdf9:b46b:5b11]:443/i/v0/e/?ip=0&_=1769042587131&ver=1.333.0&compression=gzip-js", host: "<redacted>", referrer: "https://<redacted>/"
```