### PR TITLE
fix: sync nginx template with current proxy documentation

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -18,44 +18,43 @@ http {
             return 200 'OK';
         }
         
-        # Static assets - from us-assets.i.posthog.com
-        location /static {
+        # Static assets
+        location /static/ {
             set $ph_assets ${POSTHOG_CLOUD_REGION}-assets.i.posthog.com;
-            proxy_pass https://$ph_assets;
+            proxy_pass https://$ph_assets$request_uri;
             proxy_set_header Host $ph_assets;
             proxy_ssl_server_name on;
-            
+            proxy_ssl_name $ph_assets;
+
             # Remove upstream CORS headers to prevent duplicates
             proxy_hide_header 'Access-Control-Allow-Origin';
-            proxy_hide_header 'Access-Control-Allow-Methods';
-            proxy_hide_header 'Access-Control-Allow-Headers';
-            proxy_hide_header 'Access-Control-Expose-Headers';
-            
             # Add CORS headers
             add_header 'Access-Control-Allow-Origin' '*' always;
-            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
-            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
-            add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
         }
-        
-        # Main API endpoints
+
+        location /array/ {
+            set $ph_assets ${POSTHOG_CLOUD_REGION}-assets.i.posthog.com;
+            proxy_pass https://$ph_assets$request_uri;
+            proxy_set_header Host $ph_assets;
+            proxy_ssl_server_name on;
+            proxy_ssl_name $ph_assets;
+
+            proxy_hide_header 'Access-Control-Allow-Origin';
+            add_header 'Access-Control-Allow-Origin' '*' always;
+        }
+
         location / {
             set $ph_ingest ${POSTHOG_CLOUD_REGION}.i.posthog.com;
-            proxy_pass https://$ph_ingest;
+            proxy_pass https://$ph_ingest$request_uri;
             proxy_set_header Host $ph_ingest;
             proxy_ssl_server_name on;
+            proxy_ssl_name $ph_ingest;
             
             # Remove upstream CORS headers to prevent duplicates
             proxy_hide_header 'Access-Control-Allow-Origin';
-            proxy_hide_header 'Access-Control-Allow-Methods';
-            proxy_hide_header 'Access-Control-Allow-Headers';
-            proxy_hide_header 'Access-Control-Expose-Headers';
             
             # Add CORS headers
             add_header 'Access-Control-Allow-Origin' '*' always;
-            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
-            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
-            add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
         }
     }
 }


### PR DESCRIPTION
The template has not been updated since Oct 2025, while the docs at `posthog.com` have received several functional changes since[^1].

Add the `/array/` location block to route SDK remote config requests (recording conditions, feature flags, sampling rates) to the assets origin, as described in PostHog/posthog.com@301eafc7a2 ("fix(docs): route /array/* to assets origin in all proxy guides").

Without this, config requests fall through to the ingest origin which strips cache-control headers, causing browsers to use heuristic caching and serve stale SDK config.

Add the `/static/` endpoint to the `/static/` location for correct prefix matching.

Simplify CORS header handling to match the current docs — only hide and re-add `Access-Control-Allow-Origin` instead of managing four separate CORS headers.

[^1]:
https://github.com/PostHog/posthog.com/commits/301eafc7a2557259c87f7daabb8d7f386a9dea90/contents/docs/advanced/proxy/nginx.mdx